### PR TITLE
Call 'minetest.global_exists' to check for 'intllib' mod

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -1,7 +1,7 @@
 -- boilerplate to support localized strings if intllib mod is installed
 
 local S
-if intllib then
+if minetest.global_exists("intllib") then
 	S = intllib.Getter()
 else
 	S = function(s) return s end


### PR DESCRIPTION
Fixes 'Undeclared global variable "intllib"'.