### PR TITLE
Replace deprecated function 'intllib.Getter'

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -2,7 +2,13 @@
 
 local S
 if minetest.global_exists("intllib") then
-	S = intllib.Getter()
+	if intllib.make_gettext_pair then
+		-- New method using gettext.
+		S = intllib.make_gettext_pair()
+	else
+		-- Old method using text files.
+		S = intllib.Getter()
+	end
 else
 	S = function(s) return s end
 end


### PR DESCRIPTION
- Check first for *intllib.make_gettext_pair*, otherwise continue using function *intllib.Getter*.