### PR TITLE
Updates for 5.x servers

### DIFF
--- a/README
+++ b/README
@@ -1,1 +1,0 @@
-A mod for Minetest which adds various glowing elements to enhance the ambiance of caves and the night landscape.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,6 @@
+
+# Glow
+
+## About
+
+A mod for [Luanti (Minetest)](https://luanti.org/) which adds various glowing elements to enhance the ambiance of caves and the night landscape.

--- a/depends.txt
+++ b/depends.txt
@@ -1,1 +1,2 @@
 default
+intllib?

--- a/depends.txt
+++ b/depends.txt
@@ -1,2 +1,1 @@
 default
-intllib?

--- a/init.lua
+++ b/init.lua
@@ -254,7 +254,7 @@ core.register_node("glow:fireflies", {
 			},
 		},
 	},
-	alpha = 100,
+	[core.features.use_texture_alpha and "use_texture_alpha" or "alpha"] = core.features.use_texture_alpha and "clip" or 100,
 	paramtype = "light",
 	light_source = 4,
 	walkable = false,

--- a/init.lua
+++ b/init.lua
@@ -1,7 +1,7 @@
 -- boilerplate to support localized strings if intllib mod is installed
 
 local S
-if minetest.global_exists("intllib") then
+if core.global_exists("intllib") then
 	if intllib.make_gettext_pair then
 		-- New method using gettext.
 		S = intllib.make_gettext_pair()
@@ -16,7 +16,7 @@ end
 
 -- WORMS --------------------------------------------------
 
-minetest.register_node("glow:cave_worms", {
+core.register_node("glow:cave_worms", {
 	description = S("Glow Worms"),
 	drawtype = "nodebox",
 	tiles = { "worms.png" },
@@ -38,7 +38,7 @@ minetest.register_node("glow:cave_worms", {
 		type = "fixed",
 		fixed = { -1/2, -1/2, -1/2, 1/2, -7/16, 1/2 },
 	},
-	on_place = minetest.rotate_node,
+	on_place = core.rotate_node,
 })
 
 local function near_surface(pos)
@@ -46,7 +46,7 @@ local function near_surface(pos)
 		for dy = -1, 1, 1 do
 			for dz = -1, 1, 1 do
 				local dpos = { x=pos.x+dx, y=pos.y+dy, z=pos.z+dz }
-				local light = minetest.get_node_light(dpos, 0.5) -- 0.5 means noon
+				local light = core.get_node_light(dpos, 0.5) -- 0.5 means noon
 				if light and light > 5 then
 					return true
 				end
@@ -66,37 +66,37 @@ local function place_worms(pos)
 		{ x=pos.x,   y=pos.y+1, z=pos.z   },
 	}
 	for i, cpos in ipairs(axes) do
-		if minetest.get_node(cpos).name == "default:stone" then
+		if core.get_node(cpos).name == "default:stone" then
 			local facedir = (i-1) * 4 + math.random(0, 3) -- see 6d facedir info
-			minetest.set_node(pos, { name = "glow:cave_worms", param2 = facedir })
+			core.set_node(pos, { name = "glow:cave_worms", param2 = facedir })
 			return
 		end
 	end
 end
 
 local function make_worms(pos)
-	local spot = minetest.find_node_near(pos, 1, "air")
+	local spot = core.find_node_near(pos, 1, "air")
 	if not spot or near_surface(spot) then
 		return
 	end
 	local minp = vector.subtract(pos, 6)
 	local maxp = vector.add(pos, 6)
-	if  #(minetest.find_nodes_in_area(minp, maxp, "default:lava_source")) == 0
-	and #(minetest.find_nodes_in_area(minp, maxp, "glow:cave_worms")) == 0
-	and #(minetest.find_nodes_in_area(minp, maxp, "group:water")) > 1 then
+	if  #(core.find_nodes_in_area(minp, maxp, "default:lava_source")) == 0
+	and #(core.find_nodes_in_area(minp, maxp, "glow:cave_worms")) == 0
+	and #(core.find_nodes_in_area(minp, maxp, "group:water")) > 1 then
 		place_worms(spot)
 	end
 end
 
-minetest.register_on_generated(function(minp, maxp)
-	for _,pos in pairs(minetest.find_nodes_in_area(minp, maxp, "default:stone")) do
+core.register_on_generated(function(minp, maxp)
+	for _,pos in pairs(core.find_nodes_in_area(minp, maxp, "default:stone")) do
 		if math.random() < 0.001 then
 			make_worms(pos)
 		end
 	end
 end)
 
-minetest.register_abm({
+core.register_abm({
 	nodenames = { "default:stone" },
 	neighbors = { "air" },
 	interval = 120.0,
@@ -104,7 +104,7 @@ minetest.register_abm({
 	action = make_worms,
 })
 
-minetest.register_abm({
+core.register_abm({
 	nodenames = { "glow:cave_worms" },
 	interval = 60.0,
 	chance = 10,
@@ -112,32 +112,32 @@ minetest.register_abm({
 		if math.random() < 0.7 then
 			local minp = vector.subtract(pos, 2)
 			local maxp = vector.add(pos, 2)
-			local worms_count = #(minetest.find_nodes_in_area(minp, maxp, "glow:cave_worms"))
+			local worms_count = #(core.find_nodes_in_area(minp, maxp, "glow:cave_worms"))
 			if worms_count < 20 then
-				local spot = minetest.find_node_near(pos, 3, "air")
+				local spot = core.find_node_near(pos, 3, "air")
 				if spot and not near_surface(spot) then
 					place_worms(spot)
 					return
 				end
 			end
 		end
-		minetest.remove_node(pos)
+		core.remove_node(pos)
 	end,
 })
 
 --[[
 function is_facing(pos, nodename)
 	for d = -1, 1, 2 do
-		if nodename == minetest.get_node({pos.x+d, pos.y,   pos.z  }).name then return true end
-		if nodename == minetest.get_node({pos.x,   pos.y+d, pos.z  }).name then return true end
-		if nodename == minetest.get_node({pos.x,   pos.y,   pos.z+d}).name then return true end
+		if nodename == core.get_node({pos.x+d, pos.y,   pos.z  }).name then return true end
+		if nodename == core.get_node({pos.x,   pos.y+d, pos.z  }).name then return true end
+		if nodename == core.get_node({pos.x,   pos.y,   pos.z+d}).name then return true end
 	end
 	return false
 end--]]
 
 -- clean up stupid way of doing worms ---------------------
 
-minetest.register_node("glow:stone_with_worms", {
+core.register_node("glow:stone_with_worms", {
 	description = S("Glow Worms in Stone"),
 	tiles = { "default_stone.png^worms.png" },
 	is_ground_content = true,
@@ -148,19 +148,19 @@ minetest.register_node("glow:stone_with_worms", {
 	light_source = 4,
 })
 
-minetest.register_abm({
+core.register_abm({
 	nodenames = { "glow:stone_with_worms" },
 	interval = 60.0,
 	chance = 1,
 	action = function(pos)
-		minetest.set_node(pos, { name = "default:stone" })
+		core.set_node(pos, { name = "default:stone" })
 	end,
 })
 
 
 -- SHROOMS -------------------------------------------------
 
-minetest.register_node("glow:shrooms", {
+core.register_node("glow:shrooms", {
 	description = S("Glow Shrooms"),
 	drawtype = "plantlike",
 	tiles = { "shrooms.png" },
@@ -184,7 +184,7 @@ minetest.register_node("glow:shrooms", {
 })
 
 local function add_shrooms(pos)
-	if minetest.find_node_near(pos, 2, "glow:shrooms") then
+	if core.find_node_near(pos, 2, "glow:shrooms") then
 		return
 	end
 	for nx = -1, 1, 2 do
@@ -192,10 +192,10 @@ local function add_shrooms(pos)
 			for ny = 1, -1, -1 do
 				if math.random() < 0.2 then
 					local p = { x=pos.x+nx, y=pos.y-1+ny, z=pos.z+nz }
-					if minetest.get_item_group(minetest.get_node(p).name, "soil") ~= 0 then
+					if core.get_item_group(core.get_node(p).name, "soil") ~= 0 then
 						p.y = p.y+1
-						if minetest.get_node(p).name == "air" then
-							minetest.set_node(p, { name = "glow:shrooms" })
+						if core.get_node(p).name == "air" then
+							core.set_node(p, { name = "glow:shrooms" })
 						end
 						break
 					end
@@ -205,16 +205,16 @@ local function add_shrooms(pos)
 	end
 end
 
-minetest.register_on_generated(function(minp, maxp)
-	for _,pos in pairs(minetest.find_nodes_in_area(minp, maxp, "default:tree")) do
+core.register_on_generated(function(minp, maxp)
+	for _,pos in pairs(core.find_nodes_in_area(minp, maxp, "default:tree")) do
 		if math.random() < 0.2
-		and minetest.get_node({x=pos.x, y=pos.y-1, z=pos.z}).name ~= "default:tree" then
+		and core.get_node({x=pos.x, y=pos.y-1, z=pos.z}).name ~= "default:tree" then
 			add_shrooms(pos)
 		end
 	end
 end)
 
-minetest.register_abm({
+core.register_abm({
 	nodenames = { "default:tree" },
 	neighbors = {
 		"air",
@@ -225,14 +225,14 @@ minetest.register_abm({
 	action = function(pos)
 		local minp = vector.subtract(pos, 1)
 		local maxp = vector.add(pos, 1)
-		local shroom_count = #(minetest.find_nodes_in_area(minp, maxp, "glow:shrooms"))
+		local shroom_count = #(core.find_nodes_in_area(minp, maxp, "glow:shrooms"))
 		if shroom_count == 0 or (shroom_count == 1 and math.random() < 0.3) then
 			add_shrooms(pos)
 		end
 	end,
 })
 
-minetest.register_abm({
+core.register_abm({
 	nodenames = { "glow:shrooms" },
 	neighbors = {
 		"air",
@@ -244,7 +244,7 @@ minetest.register_abm({
 		if math.random() < 0.3 then
 			add_shrooms(pos)
 		else
-			minetest.remove_node(pos)
+			core.remove_node(pos)
 		end
 	end,
 })
@@ -252,7 +252,7 @@ minetest.register_abm({
 
 -- FIREFLIES ----------------------------------------------
 
-minetest.register_node("glow:fireflies", {
+core.register_node("glow:fireflies", {
 	description = S("Fireflies"),
 	drawtype = "glasslike",
 	tiles = {
@@ -277,7 +277,7 @@ minetest.register_node("glow:fireflies", {
 	drop = "",
 })
 
-minetest.register_abm({
+core.register_abm({
 	nodenames = { "air" },
 	neighbors = {
 		"default:grass_1",
@@ -289,19 +289,19 @@ minetest.register_abm({
 	interval = 2.0,
 	chance = 300,
 	action = function(pos)
-		local time = minetest.get_timeofday()
+		local time = core.get_timeofday()
 		if time <= 0.74 and time >= 0.22 then
 			return
 		end
-		if not minetest.find_node_near(pos, 9, "glow:fireflies") then
-			minetest.set_node(pos, {name = "glow:fireflies"})
+		if not core.find_node_near(pos, 9, "glow:fireflies") then
+			core.set_node(pos, {name = "glow:fireflies"})
 		end
 	end,
 })
 
-minetest.register_abm({
+core.register_abm({
 	nodenames = {"glow:fireflies"},
 	interval = 1.0,
 	chance = 2,
-	action = minetest.remove_node,
+	action = core.remove_node,
 })

--- a/init.lua
+++ b/init.lua
@@ -1,17 +1,5 @@
--- boilerplate to support localized strings if intllib mod is installed
 
-local S
-if core.global_exists("intllib") then
-	if intllib.make_gettext_pair then
-		-- New method using gettext.
-		S = intllib.make_gettext_pair()
-	else
-		-- Old method using text files.
-		S = intllib.Getter()
-	end
-else
-	S = function(s) return s end
-end
+local S = core.get_translator(core.get_current_modname())
 
 
 -- WORMS --------------------------------------------------

--- a/locale/de.txt
+++ b/locale/de.txt
@@ -1,5 +1,0 @@
-# Translation by Xanthin
-
-Glow Worms in Stone = Gluehwuermchen im Stein
-Glow Shrooms = Leuchtpilze
-Fireflies = Leuchtkaefer

--- a/locale/glow.de.tr
+++ b/locale/glow.de.tr
@@ -1,0 +1,6 @@
+# textdomain: glow
+# Translation by Xanthin
+
+Glow Worms in Stone=Gluehwuermchen im Stein
+Glow Shrooms=Leuchtpilze
+Fireflies=Leuchtkaefer

--- a/locale/template.txt
+++ b/locale/template.txt
@@ -1,5 +1,5 @@
-# Template
+# textdomain: glow
 
-Glow Worms in Stone = 
-Glow Shrooms = 
-Fireflies = 
+Glow Worms in Stone=
+Glow Shrooms=
+Fireflies=

--- a/mod.conf
+++ b/mod.conf
@@ -1,0 +1,5 @@
+name = glow
+description = Adds various glowing elements to enhance the ambiance of caves and the night landscape.
+version = 1.7.5
+depends = default
+optional_depends = intllib

--- a/mod.conf
+++ b/mod.conf
@@ -2,4 +2,3 @@ name = glow
 description = Adds various glowing elements to enhance the ambiance of caves and the night landscape.
 version = 1.7.5
 depends = default
-optional_depends = intllib


### PR DESCRIPTION
Adds better support for recent servers.
- adds `mod.conf`
- replaces references to deprecated global "minetest" with "core"
- updates to use built-in translation library instead of depending in `intllib`
- converts README to markdown
- uses field "use_texture_alpha" instead of deprecated "alpha" in node registration for newer servers